### PR TITLE
fix: Prevent premature recording termination in Speech Recognition

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -37,10 +37,6 @@ document.addEventListener('DOMContentLoaded', () => {
             getEvaluation(lastAiQuestion, userAnswer);
         };
 
-        recognition.onspeechend = () => {
-            if(isRecording) stopRecording();
-        };
-
         recognition.onerror = (event) => {
             console.error('Speech recognition error:', event.error);
             if(isRecording) stopRecording();


### PR DESCRIPTION
This commit fixes a bug where the voice recording would stop automatically if the user paused while speaking.

The `onspeechend` event handler for the SpeechRecognition API was calling the `stopRecording()` function. This behavior has been removed. The recording will now only stop when the user manually clicks the stop button or an error occurs. This provides a better user experience, allowing users to think and speak without being cut off.