### PR TITLE
feat: Add real-time transcription display during recording

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -114,10 +114,41 @@ h1 { margin: 0; font-weight: 700; }
 /* Main Record Button */
 #user-controls {
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     gap: 1rem;
     margin-top: 8px;
+}
+
+#real-time-transcript {
+    margin: 0;
+    padding: 10px 15px;
+    background-color: #f1f1f1;
+    border-radius: 8px;
+    min-height: 1.5em;
+    width: 80%;
+    max-width: 600px;
+    color: #333;
+    font-size: 1rem;
+    text-align: center;
+    line-height: 1.5;
+    transition: all 0.2s ease-in-out;
+}
+
+#real-time-transcript:not(.is-hidden) {
+    margin-bottom: 15px;
+}
+
+#real-time-transcript .interim-text {
+    color: #888;
+}
+
+.user-controls-buttons {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
 }
 
 .record-btn {

--- a/templates/index.html
+++ b/templates/index.html
@@ -71,9 +71,12 @@
         </main>
 
         <div id="user-controls">
-            <button id="record-button" class="record-btn" aria-pressed="false" aria-label="録音開始">🎤 録音開始</button>
-            <button id="stop-button" class="record-btn is-hidden" aria-label="録音停止">⏹️ 録音停止</button>
-            <button id="cancel-button" class="record-btn is-hidden" aria-label="録音キャンセル">❌ キャンセル</button>
+            <p id="real-time-transcript" class="is-hidden" aria-live="polite"></p>
+            <div class="user-controls-buttons">
+                <button id="record-button" class="record-btn" aria-pressed="false" aria-label="録音開始">🎤 録音開始</button>
+                <button id="stop-button" class="record-btn is-hidden" aria-label="録音停止">⏹️ 録音停止</button>
+                <button id="cancel-button" class="record-btn is-hidden" aria-label="録音キャンセル">❌ キャンセル</button>
+            </div>
         </div>
 
     </div>


### PR DESCRIPTION
This commit implements a user interface enhancement to show the live transcription of the user's speech while they are recording.

Key changes:
- Added a new UI element to `index.html` to serve as the display area for the real-time transcript.
- Updated `style.css` to style the new transcript element and to visually distinguish between final and interim (in-progress) text.
- Overhauled the `SpeechRecognition` `onresult` event handler in `script.js` to correctly process both final and interim results, updating the UI in real-time.
- Modified the recording control functions (`startRecording`, `stopRecording`, `cancelRecording`) to manage the visibility and state of the new transcript display.