### PR TITLE
feat: Use specific sentence for word card context

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -292,7 +292,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 wordSpan.addEventListener('click', (event) => {
                     event.stopPropagation();
                     const surfaceWord = word.word_tokens.map(t => t.surface).join('');
-                    showWordCard({ word: surfaceWord }, fullOriginalText);
+                    showWordCard({ word: surfaceWord }, sentenceText);
                 });
                 sentenceElement.appendChild(wordSpan);
             });


### PR DESCRIPTION
The word card explanation prompt now uses the specific sentence in which the word appears, rather than the entire AI-generated response.

This was achieved by changing the `showWordCard` function call inside the `analyzeSentence` function in `static/js/script.js`. The `fullOriginalText` argument was replaced with `sentenceText`, which holds the correct, segmented sentence.